### PR TITLE
Dyn pool threshold

### DIFF
--- a/pool/config.go
+++ b/pool/config.go
@@ -92,6 +92,8 @@ type DynamicAllocationOpts struct {
 	MaxWorkers  uint64        `mapstructure:"max_workers"`
 	SpawnRate   uint64        `mapstructure:"spawn_rate"`
 	IdleTimeout time.Duration `mapstructure:"idle_timeout"`
+	// Threshold defines at what percentage of remaining free workers the dynamic allocation mechanism should be triggered
+	Threshold uint64 `mapstructure:"threshold"`
 }
 
 func (d *DynamicAllocationOpts) InitDefaults() {
@@ -114,5 +116,15 @@ func (d *DynamicAllocationOpts) InitDefaults() {
 
 	if d.IdleTimeout == 0 || d.IdleTimeout < time.Second {
 		d.IdleTimeout = time.Minute
+	}
+
+	// Set default threshold to 20% if not specified
+	if d.Threshold == 0 {
+		d.Threshold = 20
+	}
+
+	// Ensure threshold is between 0 and 100
+	if d.Threshold > 100 {
+		d.Threshold = 100
 	}
 }

--- a/pool/static_pool/pool.go
+++ b/pool/static_pool/pool.go
@@ -450,8 +450,8 @@ func (sp *Pool) takeWorker(ctxGetFree context.Context, op errors.Op) (*worker.Pr
 	if sp.cfg.DynamicAllocatorOpts != nil && !sp.cfg.Debug {
 		// Get the total number of workers
 		workers := sp.ww.List()
-		totalWorkers := len(workers)
-		freeWorkers := 0
+		totalWorkers := uint64(len(workers))
+		freeWorkers := uint64(0)
 
 		for _, w := range workers {
 			if w.State().Compare(fsm.StateReady) {


### PR DESCRIPTION
# Reason for This PR

This PR adds functionality for preemptively spawning workers when the system detects that the number of available workers has dropped below a certain threshold. The idea is to always maintain a buffer of ready-to-use workers so that RoadRunner doesn’t have to spend time creating them during peak load. Currently, if there are no free workers, RR queues the request and waits up to 2 seconds to spin up a new one, which significantly impacts performance under increasing load—especially for fast content delivery.

## Description of Changes

Add new functionality to pool and dyn_allocator: allocate new wrokers, deallocate workers.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [X] All commits in this PR are signed (`git commit -s`).
- [X] The reason for this PR is clearly provided (issue no. or explanation).
- [X] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


If this PR looks good, I’ll go ahead and make the corresponding updates to the RoadRunner documentation. I tested the functionality using load testing, monitoring how workers are spawned and released. I'm not yet sure how to properly cover this with unit tests. At the very least, I can add the new parameter to the existing test configuration files.
